### PR TITLE
Log du temps d'exécution des requêtes HTTP

### DIFF
--- a/MvcDemo/Middlewares/RequestTimeLogging/RequestTimeLoggingMiddleware.cs
+++ b/MvcDemo/Middlewares/RequestTimeLogging/RequestTimeLoggingMiddleware.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace MvcDemo.Middlewares.RequestTimeLogging
+{
+    /// <summary>
+    /// Middleware qui permet d'enregistrer dans un fichier text le temps d'exécution de chaque requête.
+    /// Les seules informations écrites concernent la méthode (GET, POST, etc...) et l'URL complète
+    /// </summary>
+    public class RequestTimeLoggingMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private const string logFilename = "requests.txt";
+
+        // Le constructeur du middleware DOIT avoir un paramètre de type RequestDelegate
+        public RequestTimeLoggingMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        // Le middleware DOIT avoir un méthode Invoke (ou InvokeAsync) 
+        // qui retourne un objet Task et dont le premier paramètre est de type HttpContext
+        public async Task InvokeAsync(HttpContext context)
+        {
+            var start = DateTime.Now;
+
+            // Exécution du middleware suivants
+            await _next(context);
+
+            var end = DateTime.Now;
+
+            // GetDisplayUrl est une méthode d'extension qui nécessite d'ajouter 
+            // using Microsoft.AspNetCore.Http.Extensions;
+            var text = $"{context.Request.Method.ToUpper()} {context.Request.GetDisplayUrl()} {Environment.NewLine}" +
+                       $"exécutée en {(end - start).TotalMilliseconds} ms {Environment.NewLine}";
+
+            await File.AppendAllTextAsync(logFilename, text);
+        }
+    }
+}

--- a/MvcDemo/Middlewares/RequestTimeLogging/RequestTimeLoggingMiddlewareExtensions.cs
+++ b/MvcDemo/Middlewares/RequestTimeLogging/RequestTimeLoggingMiddlewareExtensions.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.AspNetCore.Builder;
+
+namespace MvcDemo.Middlewares.RequestTimeLogging
+{
+    public static class RequestTimeLoggingMiddlewareExtensions
+    {
+        // Méthode d'extension sur IApplicationBuilder pour utilisation dans Startup
+        // Pour ne pas avoir à importer de namespace supplémentaire dans Startup, 
+        // on peut mettre la méthode d'extensiond ans le namespace Microsoft.AspNetCore.Builder
+        public static IApplicationBuilder UseRequestTimeLogging(
+            this IApplicationBuilder builder)
+        {
+            return builder.UseMiddleware<RequestTimeLoggingMiddleware>();
+        }
+    }
+}

--- a/MvcDemo/Startup.cs
+++ b/MvcDemo/Startup.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using MvcDemo.Middlewares.RequestTimeLogging;
 
 namespace MvcDemo
 {
@@ -48,6 +49,8 @@ namespace MvcDemo
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
             }
+
+            app.UseRequestTimeLogging();
 
             app.UseHttpsRedirection();
             app.UseStaticFiles();


### PR DESCRIPTION
Création d'un middleware qui permet de logger le temps d'exécution de chaque requête HTTP entrante

**RequestTimeLoggingMiddleware** : middleware
**RequestTimeLoggingMiddlewareExtensions** : méthode d'extension _UseRequestTimeLogging_ qui est utilisée dans _Startup.Configure_ pour enregistrer le middleware