### PR TITLE
Amélioration de l'action implémentée précédemment ( #3 )

### DIFF
--- a/MvcDemo/Controllers/HomeController.cs
+++ b/MvcDemo/Controllers/HomeController.cs
@@ -6,39 +6,24 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using MvcDemo.Data;
+using MvcDemo.Data.Repositories;
 using MvcDemo.Models;
 
 namespace MvcDemo.Controllers
 {
     public class HomeController : Controller
     {
-        private readonly MvcDemoDbContext _context;
+        private readonly IOrderRepository _orderRepository;
 
-        public HomeController(MvcDemoDbContext context)
+        public HomeController(IOrderRepository orderRepository)
         {
-            _context = context;
-
-            // Force la création de la base. Utilisé ici uniquement 
-            // parce que l'on travaille avec une In-Memory database
-            // (avec un SGBD traditionnel, on utilise les migrations)
-            _context.Database.EnsureCreated();
+            _orderRepository = orderRepository;
         }
 
         public IActionResult Index()
         {
             // get orders summaries with product names and customer name
-            var orders = 
-                _context.OrderLines
-                        .Include(ol => ol.OrderHeader)
-                            .ThenInclude(oh => oh.Customer)
-                        .GroupBy(ol => ol.OrderHeader.Id)
-                        .Select(g => new
-                        {
-                            OrderId = g.Key,
-                            Customer = g.First().OrderHeader.Customer.Name,
-                            Total = g.First().OrderHeader.TotalAmount,
-                            Products = g.Select(l => l.Product.Name)
-                        }).ToList();
+            var orders = _orderRepository.GetOrderSummaries();
 
             ViewData["orders"] = orders;
 

--- a/MvcDemo/Data/Repositories/IOrderRepository.cs
+++ b/MvcDemo/Data/Repositories/IOrderRepository.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace MvcDemo.Data.Repositories
+{
+    public interface IOrderRepository
+    {
+        IEnumerable<OrderSummary> GetOrderSummaries();
+    }
+}

--- a/MvcDemo/Data/Repositories/OrderRepository.cs
+++ b/MvcDemo/Data/Repositories/OrderRepository.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MvcDemo.Data.Repositories
+{
+    public class OrderRepository : IOrderRepository
+    {
+        private readonly MvcDemoDbContext _context;
+
+        public OrderRepository(MvcDemoDbContext context)
+        {
+            _context = context;
+
+            // Force la création de la base. Utilisé ici uniquement 
+            // parce que l'on travaille avec une In-Memory database
+            // (avec un SGBD traditionnel, on utilise les migrations)
+            _context.Database.EnsureCreated();
+
+        }
+
+        public IEnumerable<OrderSummary> GetOrderSummaries()
+        {
+            var orders =
+                _context.OrderLines
+                        .Include(ol => ol.OrderHeader)
+                            .ThenInclude(oh => oh.Customer)
+                        .GroupBy(ol => ol.OrderHeader.Id)
+                        .Select(g => new OrderSummary
+                        {
+                            OrderId = g.Key,
+                            Customer = g.First().OrderHeader.Customer.Name,
+                            Total = g.First().OrderHeader.TotalAmount,
+                            Products = g.Select(l => l.Product.Name)
+                        }).ToList();
+
+            return orders;
+        }
+    }
+}

--- a/MvcDemo/Data/Repositories/OrderSummary.cs
+++ b/MvcDemo/Data/Repositories/OrderSummary.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace MvcDemo.Data.Repositories
+{
+    public class OrderSummary
+    {
+        public int OrderId { get; set; }
+
+        public string Customer { get; set; }
+
+        public decimal Total { get; set; }
+
+        public IEnumerable<string> Products { get; set; }
+    }
+}

--- a/MvcDemo/Startup.cs
+++ b/MvcDemo/Startup.cs
@@ -11,6 +11,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using MvcDemo.Data;
+using MvcDemo.Data.Repositories;
 using MvcDemo.Middlewares.RequestTimeLogging;
 
 namespace MvcDemo
@@ -45,6 +46,8 @@ namespace MvcDemo
                                                     });
 
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+
+            services.AddTransient<IOrderRepository, OrderRepository>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
Travail basé sur l'implémentation de la PR #3 

**Découplage** : _HomeController_ n'est plus responsable du requêtage. Ce rôle est dévolu au type _OrderRepository_ => Il n'est plus nécessaire d'injecter _MvcDemoDbContext_ dans le Controller

_OrderRepository_ est ajouté au conteneur IoC de l'application au travers de l'interface _IOrderRepository_, puis il est injecté dans _HomeController_ et utilisé pour la récupération des données.